### PR TITLE
Add lambda to mark attendance

### DIFF
--- a/src/lambda/attendance/index.js
+++ b/src/lambda/attendance/index.js
@@ -13,11 +13,11 @@ const handler = async (event) => {
 
   const params = {
     ExpressionAttributeNames: {
-     "#a": "attended"
+     "#attended": "attended"
     }, 
     ExpressionAttributeValues: {
-      ":a": {
-        B: true
+      ":attended": {
+        S: "true"
       },
     }, 
     Key: {
@@ -28,7 +28,7 @@ const handler = async (event) => {
     ConditionExpression: "attribute_exists(email)",
     ReturnValues: "NONE",
     TableName,
-    UpdateExpression: "SET #a = :a"
+    UpdateExpression: "SET #attended = :attended"
   };
 
   try {

--- a/src/lambda/attendance/index.js
+++ b/src/lambda/attendance/index.js
@@ -1,0 +1,58 @@
+const AWS = require('aws-sdk')
+
+const dynamodb = new AWS.DynamoDB()
+
+const TableName = process.env.TABLENAME
+
+
+const handler = async (event) => {
+  let message = ''
+  let statusCode = 200
+
+  const body = JSON.parse(event.body)
+
+  const params = {
+    ExpressionAttributeNames: {
+     "#a": "attended"
+    }, 
+    ExpressionAttributeValues: {
+      ":a": {
+        B: true
+      },
+    }, 
+    Key: {
+     "email": {
+       S: body.email
+      }
+    },
+    ConditionExpression: "attribute_exists(email)",
+    ReturnValues: "NONE",
+    TableName,
+    UpdateExpression: "SET #a = :a"
+  };
+
+  try {
+    if (statusCode == 200) await dynamodb.updateItem(params).promise()
+  } catch (e) {
+    statusCode = 400
+    console.error(body, e)
+    message = "Something went wrong. Please try again later."
+    if (e.code === 'ConditionalCheckFailedException') {
+      message = "This email is not registered."
+    }
+  }
+
+  let response = {
+      statusCode,
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      },
+      body: JSON.stringify({message})
+  };
+
+  console.debug("response: " + JSON.stringify(response))
+
+  return response
+};
+
+module.exports = { handler }

--- a/src/website/index.html
+++ b/src/website/index.html
@@ -190,24 +190,31 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
         return
       }
 
-      const response = await fetch('https://a50jc5jboe.execute-api.us-east-1.amazonaws.com/kuberoke-kc-2023-chi-prod/attendance', {
-        method: "POST",
-        mode: "cors",
-        cache: "no-cache",
-        headers: {
-          "Content-Type": "application/json",
-          "X-API-Key": API_KEY
-        },
-        redirect: "follow",
-        referrerPolicy: "no-referrer",
-        body: JSON.stringify({
-          email: data.email
-        })
-      })
-
       alert(`${data.name} was invited ${moment(parseInt(data.qrsentat, 10)).fromNow()}, last possible arrival ${moment(parseInt(data.qrsentat, 10)).add(parseInt(data.timetoarrive || 30, 10), 'minutes').fromNow()}.`)
     } catch (error) {
       alert(error)
+    }
+
+    async function markAttendance(decodedText, decodedResult) {
+      try {
+        const data = JSON.parse(decodedText)
+        const response = await fetch('https://a50jc5jboe.execute-api.us-east-1.amazonaws.com/kuberoke-kc-2023-chi-prod/attendance', {
+          method: "POST",
+          mode: "cors",
+          cache: "no-cache",
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": API_KEY
+          },
+          redirect: "follow",
+          referrerPolicy: "no-referrer",
+          body: JSON.stringify({
+            email: data.email
+          })
+        })
+      } catch (error) {
+        alert(error)
+      }
     }
   }
 
@@ -235,6 +242,7 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
     defaultZoomValueIfSupported: 1.5
   }, false)
   html5QrcodeScanner.render(onScanSuccess);  
+  html5QrcodeScanner.render(markAttendance);
 })()
     </script>
   </body>

--- a/src/website/index.html
+++ b/src/website/index.html
@@ -176,27 +176,7 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
         }, pubKey, str2ab(atob(signature)), new TextEncoder("utf-8").encode(data))
   }
 
-  async function onScanSuccess(decodedText, decodedResult) {
-    const data = JSON.parse(decodedText)
-
-    const signature = data.signature
-
-    delete data.signature
-
-    try {
-      const res = await verifySignature(signature, JSON.stringify(data))
-      if (!res) {
-        alert('Signature is invalid.')
-        return
-      }
-
-      alert(`${data.name} was invited ${moment(parseInt(data.qrsentat, 10)).fromNow()}, last possible arrival ${moment(parseInt(data.qrsentat, 10)).add(parseInt(data.timetoarrive || 30, 10), 'minutes').fromNow()}.`)
-    } catch (error) {
-      alert(error)
-    }
-  }
-
-  async function markAttendance(decodedText, decodedResult) {
+  async function markAttendance(email) {
     try {
       const data = JSON.parse(decodedText)
       const response = await fetch('https://a50jc5jboe.execute-api.us-east-1.amazonaws.com/kuberoke-kc-2023-chi-prod/attendance', {
@@ -215,6 +195,28 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
       })
 
       alert(`${data.name} was marked as attended, welcome!`)
+    } catch (error) {
+      alert(error)
+    }
+  }
+
+  async function onScanSuccess(decodedText, decodedResult) {
+    const data = JSON.parse(decodedText)
+
+    const signature = data.signature
+
+    delete data.signature
+
+    try {
+      const res = await verifySignature(signature, JSON.stringify(data))
+      if (!res) {
+        alert('Signature is invalid.')
+        return
+      }
+
+      alert(`${data.name} was invited ${moment(parseInt(data.qrsentat, 10)).fromNow()}, last possible arrival ${moment(parseInt(data.qrsentat, 10)).add(parseInt(data.timetoarrive || 30, 10), 'minutes').fromNow()}.`)
+
+      markAttendance(data.email)
     } catch (error) {
       alert(error)
     }
@@ -243,8 +245,7 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
     showZoomSliderIfSupported: 1,
     defaultZoomValueIfSupported: 1.5
   }, false)
-  html5QrcodeScanner.render(onScanSuccess);  
-  html5QrcodeScanner.render(markAttendance);
+  html5QrcodeScanner.render(onScanSuccess);
 })()
     </script>
   </body>

--- a/src/website/index.html
+++ b/src/website/index.html
@@ -176,20 +176,39 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
         }, pubKey, str2ab(atob(signature)), new TextEncoder("utf-8").encode(data))
   }
 
-  function onScanSuccess(decodedText, decodedResult) {
+  async function onScanSuccess(decodedText, decodedResult) {
     const data = JSON.parse(decodedText)
 
     const signature = data.signature
 
     delete data.signature
 
-    verifySignature(signature, JSON.stringify(data)).then(res => {
+    try {
+      const res = await verifySignature(signature, JSON.stringify(data))
       if (!res) {
         alert('Signature is invalid.')
         return
       }
+
+      const response = await fetch('https://a50jc5jboe.execute-api.us-east-1.amazonaws.com/kuberoke-kc-2023-chi-prod/attendance', {
+        method: "POST",
+        mode: "cors",
+        cache: "no-cache",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": API_KEY
+        },
+        redirect: "follow",
+        referrerPolicy: "no-referrer",
+        body: JSON.stringify({
+          email: data.email
+        })
+      })
+
       alert(`${data.name} was invited ${moment(parseInt(data.qrsentat, 10)).fromNow()}, last possible arrival ${moment(parseInt(data.qrsentat, 10)).add(parseInt(data.timetoarrive || 30, 10), 'minutes').fromNow()}.`)
-    }).catch(alert)
+    } catch (error) {
+      alert(error)
+    }
   }
 
   let html5QrcodeScanner = new Html5QrcodeScanner("reader", {

--- a/src/website/index.html
+++ b/src/website/index.html
@@ -194,27 +194,29 @@ qFFo5+EviJb2FJc9AQ1nQXTt/mXu9BtO4/tP1Q2GeKTSj6UQWRb64rMCAwEAAQ==
     } catch (error) {
       alert(error)
     }
+  }
 
-    async function markAttendance(decodedText, decodedResult) {
-      try {
-        const data = JSON.parse(decodedText)
-        const response = await fetch('https://a50jc5jboe.execute-api.us-east-1.amazonaws.com/kuberoke-kc-2023-chi-prod/attendance', {
-          method: "POST",
-          mode: "cors",
-          cache: "no-cache",
-          headers: {
-            "Content-Type": "application/json",
-            "X-API-Key": API_KEY
-          },
-          redirect: "follow",
-          referrerPolicy: "no-referrer",
-          body: JSON.stringify({
-            email: data.email
-          })
+  async function markAttendance(decodedText, decodedResult) {
+    try {
+      const data = JSON.parse(decodedText)
+      const response = await fetch('https://a50jc5jboe.execute-api.us-east-1.amazonaws.com/kuberoke-kc-2023-chi-prod/attendance', {
+        method: "POST",
+        mode: "cors",
+        cache: "no-cache",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": API_KEY
+        },
+        redirect: "follow",
+        referrerPolicy: "no-referrer",
+        body: JSON.stringify({
+          email: data.email
         })
-      } catch (error) {
-        alert(error)
-      }
+      })
+
+      alert(`${data.name} was marked as attended, welcome!`)
+    } catch (error) {
+      alert(error)
     }
   }
 

--- a/terraform/lambda_attendance.tf
+++ b/terraform/lambda_attendance.tf
@@ -1,0 +1,76 @@
+resource "aws_iam_role" "api_attendance_handler" {
+  name               = "kuberoke-${var.environment}-api-attendance-lambda-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "api_attendance_handler" {
+  name   = "kuberoke-${var.environment}-api-attendance-lambda-policy"
+  policy = <<EOF
+{
+    "Statement": [
+        {
+            "Action": "logs:CreateLogGroup",
+            "Effect": "Allow",
+            "Resource": "arn:aws:logs:${local.region_name}:${local.account_id}:*"
+        },
+        {
+            "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogStream"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:logs:${local.region_name}:${local.account_id}:log-group:/aws/lambda/${aws_lambda_function.api_attendance_handler.function_name}:*"
+        },
+        {
+            "Action": [
+                "dynamodb:UpdateItem",
+                "dynamodb:Scan"
+            ],
+            "Effect": "Allow",
+            "Resource": "${aws_dynamodb_table.kuberoke.arn}"
+        }
+    ],
+    "Version": "2012-10-17"
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "api_attendance_handler" {
+  role       = aws_iam_role.api_attendance_handler.name
+  policy_arn = aws_iam_policy.api_attendance_handler.arn
+}
+
+data "archive_file" "api_attendance_handler" {
+  type        = "zip"
+  source_dir  = "${path.root}/../src/lambda/attendance"
+  output_path = "${path.root}/../src/lambda/build/attendance_lambda_function.zip"
+}
+
+resource "aws_lambda_function" "api_attendance_handler" {
+  filename         = "${path.root}/../src/lambda/build/attendance_lambda_function.zip"
+  function_name    = "kuberoke-${var.environment}-api-attendance"
+  handler          = "index.handler"
+  runtime          = "nodejs16.x"
+  role             = aws_iam_role.api_attendance_handler.arn
+  source_code_hash = data.archive_file.api_attendance_handler.output_base64sha256
+
+  environment {
+    variables = {
+      TABLENAME              = aws_dynamodb_table.kuberoke.name    
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a lambda that sets a new column in DynamoDB, "attended" to true, when we successfully scan a QR code. This will let us track success of events by knowing how many people actually showed up.

In addition the the lambda code, there is Terraform code that creates it, and an API gateway entry for it protected by the API key. The index.html now calls the gateway on that path when the QR code is scanned, using the email embedded in the QR code.